### PR TITLE
fix: [CI-19286]: Fix critical bugs: trailing slash URLs, absolute paths, and response body logging

### DIFF
--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: plugins/nexus-publish:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: plugins/nexus-publisher:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,18 +7,18 @@ tags:
 {{/if}}
 manifests:
   -
-    image: plugins/nexus-publish:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    image: plugins/nexus-publisher:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: plugins/nexus-publish:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    image: plugins/nexus-publisher:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: plugins/nexus-publish:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2022-amd64
+    image: plugins/nexus-publisher:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2022-amd64
     platform:
       architecture: amd64
       os: windows

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 type formatter struct{}
 
 func (*formatter) Format(entry *logrus.Entry) ([]byte, error) {
-	return []byte(entry.Message), nil
+	return []byte(entry.Message + "\n"), nil
 }
 
 // text formatter that writes logs with level information


### PR DESCRIPTION
  ## Summary

  Fixes three critical bugs preventing artifact uploads and adds informative logging for better debugging.

  ### Bugs Fixed

  Bug 1: Response body never read
  - Error messages now include detailed Nexus server responses
  - Helps diagnose authentication, permission, and validation failures

  Bug 2: Absolute file paths fail with 500 errors
  - Now extracts basename from paths (e.g., /tmp/app.jar → app.jar)
  - Works with both Linux (/path/to/file) and Windows (C:\path\to\file) paths

  Bug 3: Trailing slash URLs cause 405 errors
  - URLs like http://nexus.example.com/ now work correctly
  - Automatically strips trailing slashes

  ### Enhancements

  - Added detailed INFO logs showing upload progress, file details, and Maven coordinates

  ### Testing

  - ✅ 18/18 unit tests passing
  - ✅ Manual testing with real Nexus server
  - ✅ Verified single and multi-file uploads
  - ✅ Cross-platform compatible (Unix/Windows)

Execution [LINK](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/dronenexusrepopublishdebug2/executions/2I5q5-zuRCOpehULNhZFbw/pipeline?storeType=INLINE&step=Zwb58TQhS4q4SqKv2cOg_A&stage=mfPhUI9GQj6zV_-RlKKzWQ&childStage=&stageExecId=)

  ### Files Changed

  - plugin/plugin.go - Bug fixes and logging enhancements
  - plugin/plugin_test.go - Added 13 new test cases