### PR TITLE
[NEEDS-SCAN] fix: remediate 26 Go-stdlib CVEs (CI-23614) — bump toolchain to go1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/harness-community/drone-nexus-publish
 
-go 1.22.7
+go 1.25.0
+
+toolchain go1.25.12
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0


### PR DESCRIPTION
## Vulnerability Remediation: plugins/nexus-publisher

**Team:** ci (Harness CI Platform)
**Tickets:** [CI-23614](https://harness.atlassian.net/browse/CI-23614)
**Test image:** _not built — no docker/buildx/trivy toolchain available in this run_

**OnDemand scanner runs (Harness https://harness0.harness.io/):**
- Baseline: [zK4MyHGNQrSWqBRC7FZmWA](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/zK4MyHGNQrSWqBRC7FZmWA/pipeline)
- After:    _not run — see Summary_

---

### Summary

Bumped the Go toolchain from **1.22.7 → 1.25.12** in `go.mod` to address the 26 Critical/High
Go-stdlib CVEs listed on CI-23614 (max required fix version across the ticket is `1.25.11`).
No dependency changes were required — every CVE in the ticket is in the Go standard library and
is remediated by rebuilding the plugin binary with a fixed Go toolchain.

The remediation container in this run does **not** ship Docker, `buildx`, or `trivy`, so I was
unable to build the test image (`vinayakharness2026/nexus-publisher-test:nexus-publisher-...--debug`),
push it, or run the after-scan against a rebuilt image. The **baseline** OnDemand scan on
`plugins/nexus-publisher:latest` completed successfully and confirms `crypto/tls@1.22.7`,
`crypto/x509@1.22.7`, `net/http@1.22.7`, `net/url@1.22.7`, `net@1.22.7`, `encoding/pem@1.22.7`,
`encoding/asn1@1.22.7`, `crypto/internal/nistec@1.22.7`, `net/http/internal@1.22.7`,
`net/textproto@1.22.7`, `os@1.22.7` — all Go 1.22.7 stdlib packages — are present as
active findings. Per scanner-gating rules this PR is opened as **DRAFT** with
`RECOMMENDATION=WAIT` and the `[NEEDS-SCAN]` title prefix; the repo's own build
pipeline (or a re-run of the vuln-remediation agent in an environment with the
Docker toolchain) will produce the rebuilt image and the after-scan evidence for the
final ship decision.

---

### CVE Delta — Trivy (local scan)

_Not run — Trivy CLI not installed in this runner._

### CVE Delta — Harness OnDemand (Prisma Cloud)

Baseline counts only (top-level, whole image — includes findings unrelated to Go stdlib):

| Severity | Baseline | After | Change |
|----------|----------|-------|--------|
| Critical | 3        | —     | —      |
| High     | 5        | —     | —      |
| Medium   | 5        | —     | —      |
| Low      | 4        | —     | —      |
| Info     | 4        | —     | —      |
| Total    | 21       | —     | —      |

Go-stdlib findings @1.22.7 in baseline: `crypto/tls`, `crypto/x509`, `net/http`, `net/url`, `net`, `encoding/pem`, `encoding/asn1`, `crypto/internal/nistec`, `net/http/internal`, `net/textproto`, `os` (all 11 present).

---

### Per-Ticket CVE Status

#### CI-23614 — [P0: Customer Reported - Critical/High - plugins/nexus-publisher:latest - go@1.22.7](https://harness.atlassian.net/browse/CI-23614)

Status column is the *expected* outcome once the image is rebuilt with go1.25.12; not yet
verified by a rebuilt-image scan (see Summary).

| CVE | Package | Before | After (expected) | Required | Status | Reason |
|-----|---------|--------|------------------|----------|--------|--------|
| CVE-2025-68121 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.13  | Expected-OK | 1.25.12 >= 1.24.13 |
| CVE-2024-45336 | Go-stdlib | 1.22.7 | 1.25.12 | 1.22.11  | Expected-OK | fixed across major boundary via toolchain bump |
| CVE-2024-45341 | Go-stdlib | 1.22.7 | 1.25.12 | 1.22.11  | Expected-OK | |
| CVE-2025-22870 | Go-stdlib | 1.22.7 | 1.25.12 | 1.23.7   | Expected-OK | |
| CVE-2025-4673  | Go-stdlib | 1.22.7 | 1.25.12 | 1.23.10  | Expected-OK | |
| CVE-2025-47906 | Go-stdlib | 1.22.7 | 1.25.12 | 1.23.12  | Expected-OK | |
| CVE-2025-58183 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.8   | Expected-OK | |
| CVE-2025-58185 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.8   | Expected-OK | |
| CVE-2025-58186 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.8   | Expected-OK | |
| CVE-2025-58187 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.9   | Expected-OK | |
| CVE-2025-58188 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.8   | Expected-OK | |
| CVE-2025-61723 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.8   | Expected-OK | |
| CVE-2025-61724 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.8   | Expected-OK | |
| CVE-2025-61725 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.8   | Expected-OK | |
| CVE-2025-61726 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.12  | Expected-OK | |
| CVE-2025-61727 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.11  | Expected-OK | |
| CVE-2025-61729 | Go-stdlib | 1.22.7 | 1.25.12 | 1.24.11  | Expected-OK | |
| CVE-2026-27145 | Go-stdlib | 1.22.7 | 1.25.12 | 1.25.11  | Expected-OK | |
| CVE-2026-32280 | Go-stdlib | 1.22.7 | 1.25.12 | 1.25.9   | Expected-OK | |
| CVE-2026-32281 | Go-stdlib | 1.22.7 | 1.25.12 | 1.25.9   | Expected-OK | |
| CVE-2026-32283 | Go-stdlib | 1.22.7 | 1.25.12 | 1.25.9   | Expected-OK | |
| CVE-2026-33811 | Go-stdlib | 1.22.7 | 1.25.12 | 1.25.10  | Expected-OK | |
| CVE-2026-33814 | Go-stdlib | 1.22.7 | 1.25.12 | 1.25.10  | Expected-OK | |
| CVE-2026-39820 | Go-stdlib | 1.22.7 | 1.25.12 | 1.25.10  | Expected-OK | |
| CVE-2026-39836 | Go-stdlib | 1.22.7 | 1.25.12 | 1.25.10  | Expected-OK | |
| CVE-2026-42504 | Go-stdlib | 1.22.7 | 1.25.12 | 1.25.11  | Expected-OK | |

Legend: OK = resolved in the after-scan / PARTIAL = improved but below fix threshold / BLOCKED = no upstream fix.

---

### Changes Made

| File | Change |
|------|--------|
| `go.mod` | `go 1.22.7` → `go 1.25.0` + `toolchain go1.25.12` |

**Version selection rationale:**
- Go toolchain: chose **1.25.12** because the highest fix version required by any CVE on the ticket is `1.25.11` (CVE-2026-27145, CVE-2026-42504); `1.25.12` is the latest 1.25.x patch and covers every listed CVE. The ticket's remediation guidance was "rebuild with Go 1.25.x (latest 1.25 release)". No dependency changes required — all 26 CVEs are in the Go standard library and are fixed by rebuilding with a patched toolchain.

---

### Breaking-Change Warnings

> This is a **major** Go language version bump: `1.22.7 → 1.25.12`.
>
> Before merging, please:
> 1. Deploy to QA / staging
> 2. Run the full nexus-publisher plugin sanity suite
> 3. Verify uploads to Nexus (Maven, npm) still work end-to-end
> 4. Check the Go 1.23, 1.24, 1.25 release notes for any behaviour changes touching this plugin (default TLS versions, `net/http` behaviour, `crypto/tls` cipher deprecations)

---

### Newly Introduced CVEs

_Section blank — after-scan not yet run._

---

### Automation notes

- Runner: `claude-code-plugin` (pipeline mode)
- Missing tooling in this runner: `docker`, `buildx`, `trivy` → could not build/push a test image
- Baseline scan connector: `docker.io`
- Baseline scan status: **Success** (zK4MyHGNQrSWqBRC7FZmWA)


[CI-23614]: https://harness.atlassian.net/browse/CI-23614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ